### PR TITLE
Pin UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN BUILD_SEQUENCIAL=1 yarn install --inline-builds \
 FROM node:16-bullseye-slim
 
 ARG user=joplin
-RUN useradd --create-home --shell /bin/bash $user
+RUN useradd --uid 1001 --create-home --shell /bin/bash $user
 
 USER $user
 


### PR DESCRIPTION
Ensure that subsequent builds will use the same UID.
1001 is the current UID for the Joplin user, and ensuring it cannot change can be useful for setting a security context in Kubernetes.